### PR TITLE
In-corporate psr-17.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.5.0
+* [PSR-17](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-17-http-factory.md)
+
 # 0.4.0
 * [PSR-15](https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-15-request-handlers.md)
 * PHP 7+ only due to PSR-15 constraint.

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Asset management for PHP. This package is a fork of [Aura.Asset_Bundle](https://
 
 * [PSR-7 implementation](https://packagist.org/providers/psr/http-message-implementation).
 * [PSR-15 implementation](https://packagist.org/packages/psr/http-server-middleware)
-* [Proposed PSR-17 implementation](https://github.com/http-interop/http-factory)
-
-If you are not familiar with both, choose  [http-interop/http-factory-diactoros](https://packagist.org/packages/http-interop/http-factory-diactoros)
+* [PSR-17 implementation](https://packagist.org/packages/psr/http-factory)
 
 ### Installation
 
 ```bash
 composer require hkt/psr7-asset http-interop/http-factory-diactoros
 ```
+
+> You can use any psr-17 libraries.
 
 ### Tests
 
@@ -37,7 +37,7 @@ composer check
 
 ### PSR Compliance
 
-This attempts to comply with [PSR-1][], [PSR-2][], [PSR-4][], [PSR-7][], [PSR-15][] and the proposed [PSR-17][]. If
+This attempts to comply with [PSR-1][], [PSR-2][], [PSR-4][], [PSR-7][], [PSR-15][] and [PSR-17][]. If
 you notice compliance oversights, please send a patch via pull request.
 
 [PSR-1]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-1-basic-coding-standard.md
@@ -45,7 +45,7 @@ you notice compliance oversights, please send a patch via pull request.
 [PSR-4]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-4-autoloader.md
 [PSR-7]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-7-http-message.md
 [PSR-15]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-15-request-handlers.md
-[PSR-17]: https://github.com/php-fig/fig-standards/blob/master/proposed/http-factory/http-factory.md
+[PSR-17]: https://github.com/php-fig/fig-standards/blob/master/accepted/PSR-17-http-factory.md
 
 ## Structure of Package
 

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     },
     "require": {
         "php": "^5.6 || ^7.0",
-        "http-interop/http-factory": "^0.3",
+        "psr/http-factory": "^1.0",
         "psr/http-message": "^1.0",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "aura/di": "^3.0",
-        "http-interop/http-factory-diactoros": "^0.3",
+        "http-interop/http-factory-diactoros": "^1.0",
         "phpunit/phpunit": "^6.0"
     },
     "suggest": {

--- a/src/AssetResponder.php
+++ b/src/AssetResponder.php
@@ -1,7 +1,7 @@
 <?php
 namespace Hkt\Psr7Asset;
 
-use Interop\Http\Factory\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseFactoryInterface;
 use Psr\Http\Message\ResponseInterface;
 use SplFileObject;
 


### PR DESCRIPTION
Fixes #34 .

It looks zend framework diactoros has not still released a compatible version for psr-17. 

So relying on `http-interop/http-factory-diactoros` for the mean time.